### PR TITLE
feat: controle de evento aberto para inscrições

### DIFF
--- a/app/Evento.php
+++ b/app/Evento.php
@@ -36,4 +36,8 @@ class Evento extends Model
         return false;
     }
 
+    public function aberto() {
+        return $this->aberto == 1;
+    }
+
 }

--- a/app/Http/Controllers/AdminEventosController.php
+++ b/app/Http/Controllers/AdminEventosController.php
@@ -33,6 +33,9 @@
 			$this->col[] = ["label"=>"Nome","name"=>"nome"];
 			$this->col[] = ["label"=>"Data Inicio","name"=>"data_inicio"];
 			$this->col[] = ["label"=>"Data Fim","name"=>"data_fim"];
+			$this->col[] = ["label"=>"Aberto?","name"=>"aberto","callback"=>function($row) {
+				return ($row->aberto == 1) ? '<span class="label label-success">sim</span>' : '<span class="label label-danger">não</span>';
+			}];
 			# END COLUMNS DO NOT REMOVE THIS LINE
 
 			# START FORM DO NOT REMOVE THIS LINE
@@ -40,6 +43,7 @@
 			$this->form[] = ['label'=>'Nome','name'=>'nome','type'=>'text','validation'=>'required|min:1|max:255','width'=>'col-sm-10'];
 			$this->form[] = ['label'=>'Data Início','name'=>'data_inicio','type'=>'date','validation'=>'required|date','width'=>'col-sm-10'];
 			$this->form[] = ['label'=>'Data Fim','name'=>'data_fim','type'=>'date','validation'=>'required|date','width'=>'col-sm-10'];
+			$this->form[] = ['label'=>'Aberto','name'=>'aberto','type'=>'radio','validation'=>'required|min:0|max:1','width'=>'col-sm-10','dataenum'=>'1|Sim;0|Não'];
 			$this->form[] = ['label'=>'Link detalhes','name'=>'linkDetalhes','type'=>'text','validation'=>'required|min:1|max:255','width'=>'col-sm-10'];
 			$this->form[] = ['label'=>'Link mapa','name'=>'linkMapa','type'=>'text','validation'=>'required|min:1|max:255','width'=>'col-sm-10'];
 			$this->form[] = ['label'=>'Local','name'=>'local','type'=>'text','validation'=>'required|min:1|max:255','width'=>'col-sm-10'];

--- a/app/Http/Controllers/EventosController.php
+++ b/app/Http/Controllers/EventosController.php
@@ -38,6 +38,12 @@ class EventosController extends Controller
         if (!$evento)
             return view('evento_mensagem', ['evento' => $evento, 'mensagem' => 'Evento não encontrado']);
 
+        if(!$evento->aberto()) {
+            $evento->toUI();
+            return view('evento_mensagem', ['evento' => $evento, 'mensagem' => 'Inscrições ainda não liberadas, volte mais tarde.']);
+        }
+            
+
         if ($evento->encerrado()){
             $evento->toUI();
             return view('evento_mensagem', ['evento' => $evento, 'mensagem' => 'Inscrições encerradas!']);

--- a/database/migrations/2022_01_18_141946_adjust_eventos_flag_aberto.php
+++ b/database/migrations/2022_01_18_141946_adjust_eventos_flag_aberto.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AdjustEventosFlagAberto extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('eventos', function (Blueprint $table) {
+            $table->tinyInteger('aberto')->default(0);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+}


### PR DESCRIPTION
Flag para definição de evento aberto para inscrições.

Migration para criar campo 'aberto' na tabela eventos;
Ajuste no grid e formulário do controller de eventos;
Ajuste para exibição de mensagem caso evento esteja fechado para inscrições.