### PR TITLE
fix: calculo de valores de boleto dos dependentes pelos itens selecio…

### DIFF
--- a/app/PagSeguroIntegracao.php
+++ b/app/PagSeguroIntegracao.php
@@ -35,8 +35,15 @@ class PagSeguroIntegracao
                 'amount' => $valor,
                 'quantity' => '1'
             ]);
+        }
 
-            foreach ($inscricao->dependentes as &$dependente){
+        foreach ($inscricao->dependentes as &$dependente){
+            $codigos = [];
+            array_push($codigos, $dependente->alojamento);
+            array_push($codigos, $dependente->refeicao);
+            $valoresBoleto = $dependente->getValoresCobrarBoleto($codigos);
+
+            foreach($valoresBoleto as &$valorBoleto) {
                 $valor = Valor::getValor($valorBoleto->codigo, $valorBoleto->evento_id, $dependente->pessoa);
                 $total += $valor;
                 if($valor > 0){
@@ -49,6 +56,7 @@ class PagSeguroIntegracao
                 }
             }
         }
+
         $desconto = '';
         if($valores->totalDescontos > 0) {
             $desconto = '-'.$valores->totalDescontos.'';


### PR DESCRIPTION
…nados para os mesmos

O laço para inclusão de valores para o pagamento estava considerando os valores de boleto de acordo com os itens de refeição e hospedagem selecionados para o responsável, diferenciando apenas pelas variações (idade ou datas).
Porém, podem haver casos onde o tipo de hospedagem ou refeição é diferente para um dependente do que para o responsável.
Ajustado para utilizar os códigos selecionados para os responsáveis.