### PR TITLE
feat: registrar primeiro horário de check-in por pessoa

### DIFF
--- a/app/Http/Controllers/InscricoesController.php
+++ b/app/Http/Controllers/InscricoesController.php
@@ -228,13 +228,21 @@ class InscricoesController extends Controller
 
         DB::transaction(function() use ($inscricao, $dados, $id) {
             foreach ($inscricao->dependentes as $key => $value) {
-                $value->presencaConfirmada = $dados->dependentes[$key]["presenca"];
+                $presencaDependente = !empty($dados->dependentes[$key]["presenca"]);
+                $value->presencaConfirmada = $presencaDependente;
+                if ($presencaDependente && !$value->checkinEm) {
+                    $value->checkinEm = now();
+                }
                 $value->equipeRefeicao = $dados->equipeRefeicao;
                 $value->inscricaoPaga = 1;
                 $value->save();
             }
             
-            $inscricao->presencaConfirmada = $dados->presenca;
+            $presencaResponsavel = !empty($dados->presenca);
+            $inscricao->presencaConfirmada = $presencaResponsavel;
+            if ($presencaResponsavel && !$inscricao->checkinEm) {
+                $inscricao->checkinEm = now();
+            }
             $inscricao->valorInscricaoPago = $dados->valorInscricao;
             $inscricao->equipeRefeicao = $dados->equipeRefeicao;
             $inscricao->inscricaoPaga = 1;

--- a/database/migrations/2026_04_10_120000_add_checkin_em_to_inscricoes_table.php
+++ b/database/migrations/2026_04_10_120000_add_checkin_em_to_inscricoes_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddCheckinEmToInscricoesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('inscricoes', function (Blueprint $table) {
+            $table->timestamp('checkinEm')->nullable()->after('presencaConfirmada');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('inscricoes', function (Blueprint $table) {
+            $table->dropColumn('checkinEm');
+        });
+    }
+}


### PR DESCRIPTION
Adiciona timestamp de check-in na inscrição e grava o horário apenas na primeira confirmação de presença para responsável e dependentes, preservando dados para indicadores históricos.

Made-with: Cursor